### PR TITLE
Use the `golang-action` instead of a hand-rolled `cibuild` script

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -4,6 +4,5 @@ workflow "on push" {
 }
 
 action "go-ci" {
-	uses = "docker://golang:latest"
-	runs = "./script/cibuild"
+	uses = "piki/actions-go-builder@master"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -4,5 +4,5 @@ workflow "on push" {
 }
 
 action "go-ci" {
-	uses = "piki/golang-action@goodies"
+	uses = "cedrickring/golang-action@92b89ca0095ea0972cefaaaf1d48966d7c958553"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -4,5 +4,5 @@ workflow "on push" {
 }
 
 action "go-ci" {
-	uses = "piki/actions-go-builder@master"
+	uses = "piki/golang-action@goodies"
 }

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,6 +1,0 @@
-#!/bin/sh -ex
-
-mkdir -p $GOPATH/src/github.com/actions
-ln -s $PWD $GOPATH/src/github.com/actions/workflow-parser
-cd $GOPATH/src/github.com/actions/workflow-parser
-make


### PR DESCRIPTION
Every Go repo needs the same symbolic-link nonsense to get it to build.  Why hand-roll that in each repo?  I've [contributed](https://github.com/cedrickring/golang-action/pull/1) the code from the old `cibuild` to the [`cedrickring/golang-action`](https://github.com/cedrickring/golang-action) repo.  Because it's an external repo, I've pinned a SHA instead of a branch or tag.