### PR TITLE
Enabling go modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/actions/workflow-parser
+
+require (
+	github.com/hashicorp/hcl v1.0.0
+	github.com/soniakeys/graph v0.0.0
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
+github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/soniakeys/bits v1.0.0 h1:Rune9VFefdJvLE0Q5iRCVGiKdSu2iDihs2I6SCm7evw=
+github.com/soniakeys/bits v1.0.0/go.mod h1:7yJHB//UizrUr64VFneewK6SX5oeCf0SMbDYe2ey1JA=
+github.com/soniakeys/graph v0.0.0 h1:C/Rr8rv9wbhZIsYHcWJFoI84pkipJocMYdRteE+/PQA=
+github.com/soniakeys/graph v0.0.0/go.mod h1:lxpIbor/bIzWUAqvt1Dx92Hr63uWeyuEAbPnsjYbVwM=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/vendor/github.com/hashicorp/hcl/Makefile
+++ b/vendor/github.com/hashicorp/hcl/Makefile
@@ -6,6 +6,7 @@ fmt: generate
 	go fmt ./...
 
 test: generate
+	go get -t ./...
 	go test $(TEST) $(TESTARGS)
 
 generate:

--- a/vendor/github.com/hashicorp/hcl/decoder.go
+++ b/vendor/github.com/hashicorp/hcl/decoder.go
@@ -117,17 +117,10 @@ func (d *decoder) decode(name string, node ast.Node, result reflect.Value) error
 func (d *decoder) decodeBool(name string, node ast.Node, result reflect.Value) error {
 	switch n := node.(type) {
 	case *ast.LiteralType:
-		switch n.Token.Type {
-		case token.BOOL, token.STRING, token.NUMBER:
-			var v bool
-			s := strings.ToLower(strings.Replace(n.Token.Text, "\"", "", -1))
-			switch s {
-			case "1", "true":
-				v = true
-			case "0", "false":
-				v = false
-			default:
-				return fmt.Errorf("decodeBool: Unknown value for boolean: %s", n.Token.Text)
+		if n.Token.Type == token.BOOL {
+			v, err := strconv.ParseBool(n.Token.Text)
+			if err != nil {
+				return err
 			}
 
 			result.Set(reflect.ValueOf(v))

--- a/vendor/github.com/hashicorp/hcl/go.mod
+++ b/vendor/github.com/hashicorp/hcl/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/hcl
+
+require github.com/davecgh/go-spew v1.1.1

--- a/vendor/github.com/hashicorp/hcl/go.sum
+++ b/vendor/github.com/hashicorp/hcl/go.sum
@@ -1,0 +1,2 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/hashicorp/hcl/hcl/scanner/scanner.go
+++ b/vendor/github.com/hashicorp/hcl/hcl/scanner/scanner.go
@@ -475,26 +475,34 @@ func (s *Scanner) scanHeredoc() {
 
 // scanString scans a quoted string
 func (s *Scanner) scanString() {
+	braces := 0
 	for {
 		// '"' opening already consumed
 		// read character after quote
 		ch := s.next()
 
-		if ch == '\n' || ch < 0 || ch == eof {
+		if (ch == '\n' && braces == 0) || ch < 0 || ch == eof {
 			s.err("literal not terminated")
 			return
 		}
 
-		if ch == '"' {
+		if ch == '"' && braces == 0 {
 			break
+		}
+
+		// If we're going into a ${} then we can ignore quotes for awhile
+		if braces == 0 && ch == '$' && s.peek() == '{' {
+			braces++
+			s.next()
+		} else if braces > 0 && ch == '{' {
+			braces++
+		}
+		if braces > 0 && ch == '}' {
+			braces--
 		}
 
 		if ch == '\\' {
 			s.scanEscape()
-		}
-
-		if ch < ' ' {
-			s.err(fmt.Sprintf("control character in string: '\\u%04x'", ch))
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,0 +1,21 @@
+# github.com/davecgh/go-spew v1.1.1
+github.com/davecgh/go-spew/spew
+# github.com/hashicorp/hcl v1.0.0
+github.com/hashicorp/hcl
+github.com/hashicorp/hcl/hcl/ast
+github.com/hashicorp/hcl/hcl/parser
+github.com/hashicorp/hcl/hcl/token
+github.com/hashicorp/hcl/json/parser
+github.com/hashicorp/hcl/hcl/scanner
+github.com/hashicorp/hcl/hcl/strconv
+github.com/hashicorp/hcl/json/scanner
+github.com/hashicorp/hcl/json/token
+# github.com/pmezard/go-difflib v1.0.0
+github.com/pmezard/go-difflib/difflib
+# github.com/soniakeys/bits v1.0.0
+github.com/soniakeys/bits
+# github.com/soniakeys/graph v0.0.0
+github.com/soniakeys/graph
+# github.com/stretchr/testify v1.3.0
+github.com/stretchr/testify/assert
+github.com/stretchr/testify/require


### PR DESCRIPTION
Modules allow for the deprecation of the `GOPATH`. There is no longer a need to set it explicitly. Modules give more control to you to maintain project versioning of `dependencies`.