### PR TITLE
Update error messages for literalToStringArray

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -322,7 +322,7 @@ func (p *Parser) literalToStringArray(node ast.Node, promoteScalars bool) ([]str
 		if promoteScalars && literal.Token.Type == token.STRING {
 			return []string{literal.Token.Value().(string)}, true
 		}
-		p.addError(node, "Expected list, got %s", typename(node))
+		p.addError(node, "Expected list or string, got %s", typename(node))
 		return nil, false
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -622,7 +622,7 @@ func (p *Parser) parseUses(action *model.Action, node ast.Node) {
 	}
 }
 
-// parseUses sets the action.Runs or action.Args value based on the
+// parseCommand sets the action.Runs or action.Args value based on the
 // contents of the AST node.  This function enforces formatting
 // requirements on the value.
 func (p *Parser) parseCommand(action *model.Action, cmd model.Command, name string, node ast.Node, allowBlank bool) model.Command {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -321,8 +321,11 @@ func (p *Parser) literalToStringArray(node ast.Node, promoteScalars bool) ([]str
 	if ok {
 		if promoteScalars && literal.Token.Type == token.STRING {
 			return []string{literal.Token.Value().(string)}, true
+		} else if promoteScalars {
+			p.addError(node, "Expected list or string, got %s", typename(node))
+		} else {
+			p.addError(node, "Expected list, got %s", typename(node))
 		}
-		p.addError(node, "Expected list or string, got %s", typename(node))
 		return nil, false
 	}
 

--- a/tests/invalid/bad-dependencies.workflow
+++ b/tests/invalid/bad-dependencies.workflow
@@ -22,7 +22,7 @@ action "c" {
 #   "numWorkflows": 0,
 #   "errors":[
 #     { "line": 6, "severity": "ERROR", "message": "action `a' needs nonexistent action `z'" },
-#     { "line": 11, "severity": "ERROR", "message": "expected list, got number" },
+#     { "line": 11, "severity": "ERROR", "message": "expected list or string, got number" },
 #     { "line": 16, "severity": "ERROR", "message": "expected list, got object" }
 #   ]
 # }

--- a/tests/invalid/bad-resolves.workflow
+++ b/tests/invalid/bad-resolves.workflow
@@ -25,7 +25,7 @@ action "b" {
 #   "numActions":   2,
 #   "numWorkflows": 2,
 #   "errors":[
-#     { "line": 6, "severity": "ERROR", "message": "expected list, got number" },
+#     { "line": 6, "severity": "ERROR", "message": "expected list or string, got number" },
 #     { "line": 6, "severity": "ERROR", "message": "invalid format for `resolves' in workflow `foo', expected list of strings" },
 #     { "line": 12, "severity": "ERROR", "message": "`resolves' redefined in workflow `bar'" }
 #   ]


### PR DESCRIPTION
This PR changes the error message for `literalToStringArray` so that when `promoteScalars` is true but there's a non-string type token used, it returns `expected list or string` so that it is more in line with the core logic within the function.