### PR TITLE
Allow commas in `env` blocks

### DIFF
--- a/language.md
+++ b/language.md
@@ -153,7 +153,7 @@ env_kvp : 'env' '=' '{' env_var* '}' ;
 
 secrets_kvp : 'secrets' '=' ident_array ;
 
-env_var : IDENTIFIER '=' str ;
+env_var : IDENTIFIER '=' str ','? ;
 
 ident_array : '[' ((QUOTED_IDENTIFIER ',')* QUOTED_IDENTIFIER ','?)? ']';
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -152,6 +152,13 @@ func TestGetCommandFailure(t *testing.T) {
 	fixture(t, "invalid/bad-commands.workflow")
 }
 
+func TestCommas(t *testing.T) {
+	workflow, _ := fixture(t, "valid/commas.workflow")
+	for _, ac := range workflow.Actions {
+		assert.Equal(t, map[string]string{"FOO":"1", "BAR":"2", "BAZ":"3"}, ac.Env)
+	}
+}
+
 func TestBadEnv(t *testing.T) {
 	_, err := fixture(t, "invalid/bad-env.workflow")
 	pe := extractParserError(t, err)

--- a/tests/valid/commas.workflow
+++ b/tests/valid/commas.workflow
@@ -1,0 +1,60 @@
+workflow "foo" {
+	on = "push"
+	resolves = ["a", "b", "c", "d", "e"]
+}
+
+# commas on none
+action "a" {
+	uses="./x"
+	env={
+		FOO="1",
+		BAR="2",
+		BAZ="3",
+	}
+}
+
+# commas on all
+action "b" {
+	uses="./x"
+	env={
+		FOO="1",
+		BAR="2",
+		BAZ="3",
+	}
+}
+
+# commas on all but the last
+action "c" {
+	uses="./x"
+	env={
+		FOO="1",
+		BAR="2",
+		BAZ="3"
+	}
+}
+
+# commas on some plus last
+action "d" {
+	uses="./x"
+	env={
+		FOO="1",
+		BAR="2"
+		BAZ="3",
+	}
+}
+
+# commas on some but not last
+action "e" {
+	uses="./x"
+	env={
+		FOO="1"
+		BAR="2",
+		BAZ="3"
+	}
+}
+
+# ASSERT {
+#   "result":       "success",
+#   "numActions":   5,
+#   "numWorkflows": 1
+# }


### PR DESCRIPTION
language.md now admits that this form is legal:
```hcl
env = {
  A = "b",
  C = "d"
}
```

Commas between entries in a hash/object are the norm in most languages. They are allowed (optional) in HCL.  #36 introduced tests that assume that this form is legal, and I believe there are at least a few main.workflow files in the wild that use it.  30eeb74a0491 in #10 adapts the WIP JS parser to allow them as well.

PR #40 proposes making the parser and fixtures stricter so they don't allow these commas, but I think it's better to just make them an official (rather than de facto) part of the language.  That's what this commit does.

cc @timruffles for :eyes: on the ANTLR grammar in `language.md`
cc @OmarTawfik