### PR TITLE
Test: Update missing-resolves.workflow fixture

### DIFF
--- a/tests/invalid/missing-resolves.workflow
+++ b/tests/invalid/missing-resolves.workflow
@@ -20,7 +20,7 @@ workflow "c" {
 #     { "line": 7, "severity": "ERROR", "message": "workflow `b' must have an `on' attribute" },
 #     { "line": 8, "severity": "ERROR", "message": "workflow `b' resolves unknown action `d'" },
 #     { "line": 11, "severity": "ERROR", "message": "workflow `c' must have an `on' attribute" },
-#     { "line": 12, "severity": "ERROR", "message": "expected list, got number" },
+#     { "line": 12, "severity": "ERROR", "message": "expected list or string, got number" },
 #     { "line": 12, "severity": "ERROR", "message": "invalid format for `resolves' in workflow `c', expected list of strings" }
 #   ]
 # }


### PR DESCRIPTION
:wave: Actions team!

This PR updates the `missing-resolves.workflow` test fixture's expected message, since `resolves` can either be a list or string rather than just a list per our language specification:

https://github.com/actions/workflow-parser/blame/master/language.md#L43

Backstory: I noticed that #43 was the last PR to be merged to `master` and the latest check run was failing: https://github.com/actions/workflow-parser/runs/94124665

Here's the relevant line from that check run's details:

```golang
Error:      	"line 12: expected list or string, got number" does not contain "line 12: expected list, got number"

```

cc: @anthonysterling for review since you last touched this fixture ✌️ 