### PR TITLE
Recover errors in top-level declarations

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -465,7 +465,9 @@ func (p *Parser) parseVersion(idx int, item *ast.ObjectItem) {
 }
 
 // parseIdentifier parses the double-quoted identifier (name) for a
-// "workflow" or "action" block.
+// "workflow" or "action" block.  It returns the identifier with the
+// quotes removed, plus a boolean `ok` to indicate if quoting was parsed
+// successfully.
 func (p *Parser) parseIdentifier(key *ast.ObjectKey) (string, bool) {
 	id := key.Token.Text
 	if len(id) < 2 || id[0] != '"' || id[len(id)-1] != '"' {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -281,10 +281,12 @@ func TestNonExistentExplicitDependency(t *testing.T) {
 func TestHCLSubset(t *testing.T) {
 	_, err := fixture(t, "invalid/hcl-subset.workflow")
 	pe := extractParserError(t, err)
-	require.Equal(t, 2, len(pe.Actions))
-	assert.Equal(t, "b", pe.Actions[0].Identifier)
-	assert.Equal(t, "c", pe.Actions[1].Identifier)
-	assert.Equal(t, "./foo", pe.Actions[1].Uses.String())
+	require.Equal(t, 4, len(pe.Actions))
+	assert.Equal(t, "a", pe.Actions[0].Identifier)
+	assert.Equal(t, "",  pe.Actions[1].Identifier)
+	assert.Equal(t, "b", pe.Actions[2].Identifier)
+	assert.Equal(t, "c", pe.Actions[3].Identifier)
+	assert.Equal(t, "./foo", pe.Actions[3].Uses.String())
 }
 
 func TestSecrets(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -385,7 +385,10 @@ func assertParseError(t *testing.T, err error, nactions int, nflows int, workflo
 		assert.Equal(t, nflows, len(pe.Workflows), "workflows")
 
 		if len(pe.Errors) > 0 {
-			t.Log("Actual errors:  ", pe.Errors)
+			t.Log("Actual errors:")
+			for _, e := range pe.Errors {
+				t.Log("  ", e)
+			}
 		}
 		for _, e := range pe.Errors {
 			assert.NotEqual(t, 0, e.Pos.Line, "error position not set")
@@ -521,7 +524,10 @@ func fixture(t *testing.T, filename string) (*model.Configuration, error) {
 				if suppressed == 0 && level.ignore != "" {
 					continue
 				}
-				t.Log("Expected errors:", messages)
+				t.Log("Expected errors:")
+				for _, msg := range messages {
+					t.Log("  ", msg)
+				}
 				if len(messages) > 0 {
 					assertParseError(t, err, a.NumActions, a.NumWorkflows, workflow, messages...)
 				} else {

--- a/tests/invalid/hcl-subset.workflow
+++ b/tests/invalid/hcl-subset.workflow
@@ -9,12 +9,14 @@ action "c" { uses="./foo" }
 
 # ASSERT {
 #   "result":       "failure",
-#   "numActions":   2,
+#   "numActions":   4,
 #   "numWorkflows": 0,
 #   "errors":[
 #     { "line": 4, "severity": "ERROR", "message": "invalid toplevel declaration" },
-#     { "line": 5, "severity": "ERROR", "message": "invalid toplevel keyword" },
+#     { "line": 4, "severity": "ERROR", "message": "action `a' must have a `uses' attribute" },
+#     { "line": 5, "severity": "ERROR", "message": "invalid toplevel keyword, `hello'" },
 #     { "line": 6, "severity": "ERROR", "message": "invalid format for identifier" },
+#     { "line": 6, "severity": "ERROR", "message": "action `' must have a `uses' attribute" },
 #     { "line": 7, "severity": "ERROR", "message": "each attribute of action `b' must be an assignment" },
 #     { "line": 7, "severity": "ERROR", "message": "expected string, got object" },
 #     { "line": 7, "severity": "ERROR", "message": "action `b' must have a `uses' attribute" }


### PR DESCRIPTION
Issue #42 pointed out that a more robust parser can extract 4 actions, not 2, from `hcl-subset.workflow`.  Now the Go parser can do that, too.  Specifically, it now recovers from:
 - extraneous toplevel identifiers, like `action "a" "b" { ... }`
 - empty toplevel identifiers, like `action "" { ... }`

To be clear, these are both still errors!  They just now produce entries in the `pe.Actions` or `pe.Workflows` array returned with the error object `pe`.

The syntax errors [identified](https://github.com/actions/workflow-parser/issues/42#issuecomment-484888046) in #42 aren't addressed here, because that would require deep changes to `hashicorp/hcl`.  This PR only addresses errors that are valid HCL but invalid in `.workflow` files.

cc @OmarTawfik 