### PR TITLE
Allow heredocs

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -303,6 +303,21 @@ func TestUnknownAttributes(t *testing.T) {
 	fixture(t, "invalid/bad-attributes.workflow")
 }
 
+func TestHeredocs(t *testing.T) {
+	workflow, _ := fixture(t, "valid/heredocs.workflow")
+
+	assert.Equal(t, []string{"a"}, workflow.Workflows[0].Resolves)
+	assert.Equal(t, &model.UsesPath{"x"}, workflow.Actions[0].Uses)
+	assert.Equal(t, &model.UsesPath{"y"}, workflow.Actions[1].Uses)
+
+	assert.Equal(t, map[string]string{"a":"b", "c":"foo"}, workflow.Actions[0].Env)
+	assert.Equal(t, &model.StringCommand{Value: "cmd; 2; 3"}, workflow.Actions[0].Runs)
+	assert.Equal(t, []string{"cmd;", "2;", "3"}, workflow.Actions[0].Runs.Split())
+
+	assert.Equal(t, &model.StringCommand{Value: "foo bar baz"}, workflow.Actions[1].Args)
+	assert.Equal(t, []string{"foo", "bar", "baz"}, workflow.Actions[1].Args.Split())
+}
+
 func TestReservedVariables(t *testing.T) {
 	_, err := fixture(t, "invalid/reserved-variables.workflow")
 	pe := extractParserError(t, err)

--- a/tests/valid/heredocs.workflow
+++ b/tests/valid/heredocs.workflow
@@ -1,0 +1,40 @@
+workflow "foo" {
+	on=<<EOF
+		push
+	EOF
+	resolves=["a"]
+}
+
+action "a" {
+	uses=<<EOF
+		./x
+	EOF
+	runs=<<EOF
+		cmd;
+		2;
+		3
+	EOF
+	env={
+		a="b"
+		c=<<EOF
+			foo
+		EOF
+	}
+}
+action "b" {
+	uses=<<EOF
+		./y
+	EOF
+	needs=["a"]
+	args=<<EOF
+		foo
+		bar
+		baz
+	EOF
+}
+
+# ASSERT {
+#   "result":       "success",
+#   "numActions":   2,
+#   "numWorkflows": 1
+# }


### PR DESCRIPTION
They're allowed as any right-hand value in any object block.  In particular, this includes `cmd` and `args`, but also the values of environment variables in `env` blocks.

To avoid downstream problems introducing newlines where they don't make sense, the parser compresses all whitespace, including newlines, to a single `" "` character.

Resolves #48.