### PR TITLE
vim + docs: correct usage of syntax files

### DIFF
--- a/syntax/workflow.vim
+++ b/syntax/workflow.vim
@@ -1,16 +1,18 @@
 " GitHub Actions Workflow (.workflow) syntax file
 " Language:     GitHub Actions Workflow
-" Last change:  2018 Feb 21
-" To use this file, copy it to ~/.vim/syntax/ and add a line like these to
-" your vimrc:
-"   augroup syntax
-"   au BufNewFile,BufReadPost *.workflow so ~/.vim/syntax/workflow.vim
-"   augroup END
-"   au BufNewFile,BufReadPost *.workflow set filetype=workflow
+" Last change:  2019 Aug 12
 
+" Usage:
+"   1. Copy this file to ~/.vim/syntax/workflow.vim
+"   2. Detect workflow filetypes in ~/.vim/syntax/ftdetect/workflow.vim:
+" >
+" au BufNewFile,BufRead *.workflow setfiletype workflow
+" <
+"   3. Enable syntax in your vimrc:
+" >
+" syntax enable
+" <
 
-
-" au BufNewFile,BufReadPost *.workflow so ~/.vim/syntax/workflow.vim
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
- number and order the steps for ease of reading
- break out code from steps
- instruct vimmers to use ftdetect
- use setfiletype (see :help setfiletype)
- add necessary instructions to see syntax highlighting

Vim syntax files belong in `~/.vim/syntax,` as correctly noted, though
I've made the pathname more explicit. However, the standard mechanism
for _using_ them is via `syntax enable`. It work ~automagically~ for
you if you correctly detect filetype: the standard mechanism there is
ftdetect (see :help ftdetect).

N.B. ftdetect does not need augroup (it gets one for free).